### PR TITLE
Add image sizes and file extension guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/.idea
+/vendor
+/node_modules
+package-lock.json
+composer.phar
+composer.lock
+phpunit.xml
+.phpunit.result.cache
+.DS_Store
+Thumbs.db

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -98,19 +98,14 @@ return [
 	 */
 
 	'resize'    => [
-
 		'image'     => 'Image',     # Label from types (Set `null` to disable resizing)
-
 		'width'     => 1200,        # Maximum width in pixels
-
 		'height'    => null,        # Maximum height in pixels
-
 		'driver'    => 'gd',        # `gd` or `imagick` http://image.intervention.io/getting_started/configuration
-
 		'quality'   => 80,          # 0 - 100
-
 		'crop'      => true,        # Cropping image on the frontend
+	],
 
-	]
+    'sizes'    => [],
 
 ];

--- a/src/Core/Controller.php
+++ b/src/Core/Controller.php
@@ -2,6 +2,7 @@
 
 namespace ClassicO\NovaMediaLibrary\Core;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
 
 class Controller {
@@ -76,10 +77,14 @@ class Controller {
 		if ( count($get) > 0 ) {
 			$array = [];
 			foreach ($get as $key) {
-				$array[] = Helper::getFolder($key->path);
+			    /** Grab all existed image sizes for deleting */
+			    $extension = pathinfo($key->path, PATHINFO_EXTENSION);
+                $path = mb_substr($key->path, 0, -(mb_strlen($extension)+1)) . "*.$extension";
+
+				$array = array_merge($array, File::glob(Helper::storage()->path(Helper::getFolder($path))));
 			}
 
-			Helper::storage()->delete($array);
+            File::delete($array);
 		}
 
 		return [ 'status' => !!$delete ];

--- a/src/Core/Helper.php
+++ b/src/Core/Helper.php
@@ -106,7 +106,8 @@ class Helper {
      *
      * @return string|null
      */
-    static function getImageUri($image, $size = null, $empty = false) {
+    static function getImageUri($image, $size = null, $empty = false)
+    {
 	    if (! is_a($image, 'ClassicO\NovaMediaLibrary\Core\Model')) {
 	        $image = Model::where('id', $image)->orWhere('path', $image)->first();
 
@@ -139,7 +140,8 @@ class Helper {
      *
      * @return array
      */
-    static function getImageSizes($image, $empty = false) {
+    static function getImageSizes($image, $empty = false)
+    {
 	    $output = [];
 
 	    if(!is_array(config('media-library.sizes'))) {

--- a/src/Core/Upload.php
+++ b/src/Core/Upload.php
@@ -2,8 +2,9 @@
 
 namespace ClassicO\NovaMediaLibrary\Core;
 
-use finfo;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Str;
+use Symfony\Component\Mime\MimeTypes;
 
 class Upload {
 
@@ -27,7 +28,7 @@ class Upload {
 		$this->resize = $this->config['resize'];
 		$this->file = $file;
 		$this->mime = explode('/', $file->getMimeType())[0];
-		$this->extension = strtolower($file->getClientOriginalExtension());
+		$this->extension = $this->guessExtension($file);
 		$this->sizes = $this->config['sizes'] ?? null;
 	}
 
@@ -54,8 +55,9 @@ class Upload {
 		if ( !is_int($this->resize['width']) )  $this->resize['width'] = null;
 		if ( !is_int($this->resize['height']) ) $this->resize['height'] = null;
 
-		if (
+        if (
 			'image' == $this->mime and
+            'svg' != $this->extension and
 			$this->resize['image'] === $this->type and
 			( $this->resize['width'] or $this->resize['height'] ) and
 			class_exists('\Intervention\Image\ImageManager')
@@ -128,8 +130,32 @@ class Upload {
 		}
 	}
 
-	private function make_sizes() {
-	    if (! empty($this->sizes) && class_exists('\Intervention\Image\ImageManager')) {
+    private function guessExtension(UploadedFile $file) : string
+    {
+        $client_extension = strtolower($file->getClientOriginalExtension());
+        $guess_extension = MimeTypes::getDefault()->getExtensions($file->getMimeType());
+
+        if(!empty($guess_extension) && in_array($client_extension, $guess_extension)){
+            return $client_extension == 'jpeg' ? 'jpg' : $client_extension;
+        } else {
+            //unify jpeg extension
+            $extension = $file->extension() == 'jpeg' ? 'jpg' : $file->extension();
+
+            return $extension ?: (
+            $file->getMimeType() == 'image/svg' ?
+                'svg' : $client_extension
+            );
+        }
+    }
+
+	private function make_sizes()
+    {
+	    if (
+            'image' == $this->mime &&
+            'svg' != $this->extension &&
+	        !empty($this->sizes) &&
+            class_exists('\Intervention\Image\ImageManager')
+        ) {
             foreach ($this->sizes as $name => [
                     'width' => $width,
                     'height' => $height,
@@ -137,32 +163,26 @@ class Upload {
             ]) {
                 if($name) {
                     if((int) $width > 0 || (int) $height > 0){
-                        if ('image' == $this->mime) {
-                            $manager = new \Intervention\Image\ImageManager(['driver' => $this->resize['driver']]);
-                            $image = $manager->make($this->file);
-                            $start = $image->width();
+                        $manager = new \Intervention\Image\ImageManager(['driver' => $this->resize['driver']]);
+                        $image = $manager->make($this->file);
+                        $start = $image->width();
 
-                            if ((int)$width > 0 && (int)$height > 0 && $crop) {
-                                $image->fit($width, $height, function ($constraint) {
-                                    $constraint->upsize();
-                                });
-                            } else {
-                                $image->resize($width, $height, function ($constraint) {
-                                    $constraint->aspectRatio();
-                                    $constraint->upsize();
-                                });
-                            }
+                        if ((int)$width > 0 && (int)$height > 0 && $crop) {
+                            $image->fit($width, $height, function ($constraint) {
+                                $constraint->upsize();
+                            });
+                        } else {
+                            $image->resize($width, $height, function ($constraint) {
+                                $constraint->aspectRatio();
+                                $constraint->upsize();
+                            });
+                        }
 
-                            if($start != $image->width()){
-                                $image = $image->stream(null, $this->resize['quality'])->__toString();
-                                $path = mb_substr($this->path, 0, -(mb_strlen($this->extension)+1)) . "-$name.{$this->extension}" ;
-                                logger('OBJ PATH ' . print_r($this->path,true));
-                                logger('OBJ EXT  ' . print_r($this->extension,true));
-                                logger('Computed ' . print_r($path,true));
-                                logger('===============================================================');
+                        if($start != $image->width()){
+                            $image = $image->stream(null, $this->resize['quality'])->__toString();
+                            $path = mb_substr($this->path, 0, -(mb_strlen($this->extension)+1)) . "-$name.{$this->extension}";
 
-                                Helper::storage()->put(Helper::getFolder($path), $image);
-                            }
+                            Helper::storage()->put(Helper::getFolder($path), $image);
                         }
                     }
                 }


### PR DESCRIPTION
Hi, I have some improvement for your media library package.

For creating image sizes, you need to add `sizes` array to package config:
```php
    /**
     * Additional image sizes
     * keys: any string, except `original` (reserved for base image)
     * values: [
     *     width:  int|null, required
     *     height: int|null, required
     *     crop:   bool, required
     * ]
     * crop: resizing strategy; if false, resize (http://image.intervention.io/api/resize) used, otherwise fit (http://image.intervention.io/api/fit)
     */
    'sizes'    => [
        'thumb' => [
            'width'  => 280,
            'height' => 280,
            'crop' => true,
        ],
        'medium' => [
            'width'  => 600,
            'height' => 400,
            'crop' => false,
        ],
        'large' => [
            'width'  => 1200,
            'height' => 750,
            'crop' => false,
        ],
    ],
```