### PR TITLE
Fix: Correcty load migrations

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -17,10 +17,10 @@ class ToolServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-media-library');
         $this->loadJsonTranslationsFrom(resource_path('lang/vendor/nova-media-library'));
+        $this->loadMigrationsFrom(__DIR__.'/../database/');
 
 	    $this->publishes([
 		    __DIR__.'/../config/' => config_path(),
-		    __DIR__.'/../database/' => base_path('/database/migrations'),
 		    __DIR__.'/../resources/lang' => resource_path('lang/vendor/nova-media-library'),
 	    ], 'config-nml');
 


### PR DESCRIPTION
database/migrations couldn't be published, the migrations folder doesn't exist.
By using `loadMigrationsFrom()` we ensure that the migrations are also loaded correctly during testing.