### PR TITLE
Fix out of memory by streaming file content at upload

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -25,8 +25,9 @@ class API {
 	{
 		try {
 			$base = basename(parse_url(($path), PHP_URL_PATH));
-			$content = file_get_contents($path);
-			Storage::disk('local')->put('nml_temp/' . $base, $content);
+			$stream = fopen($base, 'r+');
+			Storage::disk('local')->writeStream('nml_temp/' . $base, $stream);
+			fclose($stream);
 
 			$file = new UploadedFile(storage_path('app/nml_temp/' . $base), $base);
 			if ( !$file ) throw new \Exception(__('The file was not downloaded for unknown reasons'), 0);


### PR DESCRIPTION
Fixes #46 

The current upload process is reading in memory the file content several times:
* one time during the API upload to save the uploaded file to a temporary file
* and in `\Core\Upload::byDefault`, `byResize` and `setWH`

All those read-to-memory can be replaced by streaming alternatives. Read-to-memory is not an issue if you upload small images or documents, but if you want to upload large archives (ie > 50MB) you end up with an out of memory issue at the PHP level. Increasing `memory_limit` is not a scalable solution.

The benefits of using stream, is that it also allows to store the file externally (like on S3) without having to write again a temporary file.

Note that `getimagesize` used in `\Core\Upload::setWH` is only meaningful for images, and has the tendency to read the whole file if it's not an image. The idea in this case is to try to determine the image size only if the file type is image.

Thanks for considering this PR. Let me know if there's anything I can do to have it merged upstream.
